### PR TITLE
[bugfix] close old connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,10 +107,12 @@ func WithFutureTimeout(timeout time.Duration) OptionFunc {
 	}
 }
 
-func (cli *Client) ResetConn(conn redigo.Conn) {
+func (cli *Client) ResetConn(conn redigo.Conn) redigo.Conn {
 	cli.mu.Lock()
 	defer cli.mu.Unlock()
+	old := cli.conn
 	cli.conn = conn
+	return old
 }
 
 func (cli *Client) getConn() redigo.Conn {

--- a/delay_queue.go
+++ b/delay_queue.go
@@ -1,0 +1,90 @@
+package sredis
+
+import (
+	"container/heap"
+	"sync"
+
+	redigo "github.com/garyburd/redigo/redis"
+)
+
+type CloseConnectionEvent struct {
+	deadline int64
+	conn     redigo.Conn
+}
+
+type CloseConnectionEventQueue []CloseConnectionEvent
+
+func (q *CloseConnectionEventQueue) Len() int {
+	return len(*q)
+}
+
+func (q *CloseConnectionEventQueue) Less(i, j int) bool {
+	return (*q)[i].deadline < (*q)[j].deadline
+}
+
+func (q *CloseConnectionEventQueue) Swap(i, j int) {
+	if i < 0 || j < 0 {
+		return
+	}
+	(*q)[i], (*q)[j] = (*q)[j], (*q)[i]
+}
+
+func (q *CloseConnectionEventQueue) Pop() interface{} {
+	old := *q
+	n := q.Len()
+	if n == 0 {
+		return nil
+	}
+	x := old[n-1]
+	*q = old[0 : n-1]
+	return x
+}
+
+func (q *CloseConnectionEventQueue) Push(x interface{}) {
+	*q = append(*q, x.(CloseConnectionEvent))
+}
+
+type SimpleDelayQueue struct {
+	queue CloseConnectionEventQueue
+	mutex *sync.Mutex
+}
+
+func NewSimpleDelayQueue() *SimpleDelayQueue {
+	return &SimpleDelayQueue{
+		mutex: &sync.Mutex{},
+	}
+}
+
+func (q *SimpleDelayQueue) Push(deadline int64, conn redigo.Conn) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	heap.Push(&q.queue, CloseConnectionEvent{
+		deadline: deadline,
+		conn:     conn,
+	})
+}
+
+func (q *SimpleDelayQueue) PopMany(deadline int64) []redigo.Conn {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	var results []redigo.Conn
+	for {
+		res := heap.Pop(&q.queue)
+		if res == nil {
+			break
+		}
+		event, ok := res.(CloseConnectionEvent)
+		if !ok {
+			continue
+		}
+		if event.deadline <= deadline {
+			results = append(results, event.conn)
+		} else {
+			heap.Push(&q.queue, event)
+			break
+		}
+	}
+	return results
+}

--- a/delay_queue_test.go
+++ b/delay_queue_test.go
@@ -1,0 +1,87 @@
+package sredis
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type pint int64
+
+func (p pint) Priority() int64 {
+	return int64(p)
+}
+
+func TestSimpleDelayQueue(t *testing.T) {
+	queue := NewSimpleDelayQueue()
+
+	for i := 1; i < 10; i++ {
+		for j := 0; j < i; j++ {
+			queue.Push((int64(i)), nil)
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		results := queue.PopMany(int64(i))
+		assert.Equal(t, i, len(results))
+	}
+
+	// queue is empty
+	for i := 0; i < 10; i++ {
+		results := queue.PopMany(int64(i))
+		assert.Equal(t, 0, len(results))
+	}
+}
+
+func TestSimpleDelayQueue2(t *testing.T) {
+	queue := NewSimpleDelayQueue()
+
+	for i := 1; i < 10; i++ {
+		for j := 0; j < i; j++ {
+			queue.Push((int64(i)), nil)
+		}
+	}
+
+	// (1 + 9) * 10 / 2
+	results := queue.PopMany(int64(10))
+	assert.Equal(t, 45, len(results))
+
+	// queue is empty
+	for i := 0; i < 10; i++ {
+		results := queue.PopMany(int64(i))
+		assert.Equal(t, 0, len(results))
+	}
+}
+
+func BenchmarkSimpleDelayQueuePush(b *testing.B) {
+	queue := NewSimpleDelayQueue()
+	for i := 0; i < b.N; i++ {
+		queue.Push(rand.Int63(), nil)
+	}
+}
+
+func BenchmarkSimpleDelayQueuePop(b *testing.B) {
+	queue := NewSimpleDelayQueue()
+	for i := 0; i < b.N; i++ {
+		queue.PopMany(rand.Int63())
+	}
+}
+
+func BenchmarkSimpleDelayQueuePush2(b *testing.B) {
+	queue := NewSimpleDelayQueue()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			queue.Push(rand.Int63(), nil)
+		}
+	})
+}
+
+func BenchmarkSimpleDelayQueuePop2(b *testing.B) {
+	queue := NewSimpleDelayQueue()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			queue.PopMany(rand.Int63())
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/17cargo/sredis
 
 go 1.12
 
-require github.com/gomodule/redigo v2.0.0+incompatible
+require (
+	github.com/garyburd/redigo v1.6.0
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
+github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/sredis.go
+++ b/sredis.go
@@ -36,7 +36,7 @@ func (r *SRedis) OpenWithConfig(config RedisConfig) error {
 	if config.Size <= 0 {
 		config.Size = 1
 	}
-	r.client = NewRoundRobinAsyncClient(dial, config.Size)
+	r.client = NewRoundRobinAsyncClient(dial, SetRoundRobinAsyncClientConnectionCount(config.Size))
 	return nil
 }
 


### PR DESCRIPTION
修复重连客户端后，旧客户端未关闭的问题。

使用一个延时队列保存需要关闭的连接，每秒执行一次。